### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/scholar-import.el
+++ b/scholar-import.el
@@ -30,6 +30,7 @@
 
 (require 'org-protocol)
 (require 'request)
+(require 's)
 
 (defgroup scholar-import nil
   "Emacs package to import Bibtex & PDF from Google Scholar."
@@ -89,7 +90,7 @@
   "Append TEXT to the end of a given FILE."
   (save-excursion
     (with-temp-buffer
-      (insert-file file)
+      (insert-file-contents file)
       (goto-char (point-max))
       (insert text)
       (write-file file))))


### PR DESCRIPTION
- load s.el explicitly
- use insert-file-contents because insert-file is interactive use only.

```
scholar-import.el:92:8: Warning: ‘insert-file’ is for interactive use only;
    use ‘insert-file-contents’ instead.

In end of data:
scholar-import.el:78:22: Warning: the function ‘s-match’ is not known to be
    defined.
```